### PR TITLE
New implementation for creating entities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,40 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bitflags"
@@ -25,6 +55,15 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -64,6 +103,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
+name = "indexmap"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +162,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "object"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,11 +201,24 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
+ "backtrace",
  "cfg-if",
  "libc",
+ "petgraph",
  "redox_syscall",
  "smallvec",
+ "thread-id",
  "windows-targets",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -151,16 +261,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "thread-id"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-targets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ homepage = "https://dynamicgoose.github.io/magma3d-engine/"
 repository = "https://github.com/DynamicGoose/magma-ecs"
 
 [dependencies]
-parking_lot = "0.12.3"
+parking_lot = { version = "0.12.3", features = ["deadlock_detection"] }
 rayon = "1.10.0"
 roaring = "0.10.6"

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -24,7 +24,7 @@ pub(crate) type ComponentMap = HashMap<TypeId, RwLock<Vec<Option<Component>>>>;
 #[derive(Debug, Default)]
 pub struct Entities {
     components: ComponentMap,
-    bit_masks: HashMap<TypeId, RoaringBitmap>,
+    bit_masks: HashMap<TypeId, u32>,
     map: RwLock<Vec<RoaringBitmap>>,
 }
 
@@ -32,9 +32,7 @@ impl Entities {
     pub(crate) fn register_component<T: Any + Send + Sync>(&mut self) {
         let type_id = TypeId::of::<T>();
         self.components.insert(type_id, RwLock::new(vec![]));
-        let mut bit_mask = RoaringBitmap::new();
-        bit_mask.insert(1 << self.bit_masks.len());
-        self.bit_masks.insert(type_id, bit_mask);
+        self.bit_masks.insert(type_id, self.bit_masks.len() as u32);
     }
 
     pub(crate) fn create_entity(&self, components: impl ComponentSet) -> Result<(), EntityError> {
@@ -46,40 +44,42 @@ impl Entities {
             .find_any(|(_, mask)| mask.is_empty())
         {
             components.for_components(|type_id, component| {
-                let component_mask = if let Some(component_mask) = self.bit_masks.get(&type_id) {
-                    component_mask
+                if let Some(component_vec) = self.components.get(&type_id) {
+                    let mut component_vec = component_vec.write();
+                    let component_stored = component_vec.get_mut(index).unwrap();
+                    *component_stored = Some(component);
+
+                    let bit_mask = self.bit_masks.get(&type_id).unwrap();
+                    map[index].insert(*bit_mask);
                 } else {
                     result = Err(EntityError::ComponentNotRegistered);
-                    return;
                 };
-                map[index] |= component_mask;
-                let component_vec = self.components.get(&type_id).unwrap();
-                component_vec.write()[index] = Some(component);
             });
             result
         } else {
             self.components
                 .par_iter()
                 .for_each(|(_, components)| components.write().push(None));
-            map.push(RoaringBitmap::from_sorted_iter(0..1).unwrap());
+            map.push(RoaringBitmap::new());
 
             let index = map.len() - 1;
             components.for_components(|type_id, component| {
-                let component_mask = if let Some(component_mask) = self.bit_masks.get(&type_id) {
-                    component_mask
+                if let Some(component_vec) = self.components.get(&type_id) {
+                    let mut component_vec = component_vec.write();
+                    let component_stored = component_vec.get_mut(index).unwrap();
+                    *component_stored = Some(component);
+
+                    let bit_mask = self.bit_masks.get(&type_id).unwrap();
+                    map[index].insert(*bit_mask);
                 } else {
                     result = Err(EntityError::ComponentNotRegistered);
-                    return;
                 };
-                map[index] |= component_mask;
-                let component_vec = self.components.get(&type_id).unwrap();
-                component_vec.write()[index] = Some(component);
             });
             result
         }
     }
 
-    pub(crate) fn get_bitmask(&self, type_id: &TypeId) -> Option<&RoaringBitmap> {
+    pub(crate) fn get_bitmask(&self, type_id: &TypeId) -> Option<&u32> {
         self.bit_masks.get(type_id)
     }
 
@@ -95,9 +95,7 @@ impl Entities {
         };
 
         let mut map = self.map.write();
-        if &map[index] & mask == *mask {
-            map[index] ^= mask;
-        }
+        map[index].remove(*mask);
         Ok(())
     }
 
@@ -112,7 +110,7 @@ impl Entities {
         } else {
             return Err(EntityError::ComponentNotRegistered);
         };
-        self.map.write()[index] |= mask;
+        self.map.write()[index].insert(*mask);
 
         let components = self.components.get(&type_id).unwrap();
         components.write()[index] = Some(Arc::new(RwLock::new(data)));
@@ -153,7 +151,7 @@ mod test {
         entities.register_component::<Speed>();
         let type_id = TypeId::of::<Speed>();
         let mask = entities.bit_masks.get(&type_id).unwrap();
-        assert!(mask.contains(2));
+        assert_eq!(*mask, 1);
     }
 
     #[test]
@@ -207,8 +205,8 @@ mod test {
         entities.create_entity((Health(100),)).unwrap();
 
         let entity_map = entities.map.read();
-        assert!(entity_map[0].contains_range(1..2));
-        assert!(entity_map[1].contains(1));
+        assert!(entity_map[0].contains(0) && entity_map[0].contains(1));
+        assert!(entity_map[1].contains(0));
     }
 
     #[test]
@@ -221,7 +219,7 @@ mod test {
 
         entities.remove_component_by_entity_id::<Health>(0).unwrap();
 
-        assert_eq!(entities.map.read()[0].min().unwrap(), 2);
+        assert!(entities.map.read()[0].contains(1) && !entities.map.read()[0].contains(0));
     }
 
     #[test]
@@ -262,7 +260,7 @@ mod test {
             .read()[0];
         let health_borrowed = health.as_ref().unwrap().read();
         let health_downcast = health_borrowed.downcast_ref::<Health>().unwrap();
-        assert!(entities.map.read()[0].contains(1));
+        assert!(entities.map.read()[0].contains(0));
         assert_eq!(health_downcast.0, 25);
     }
 

--- a/src/entities/component_set.rs
+++ b/src/entities/component_set.rs
@@ -1,0 +1,62 @@
+use std::{
+    any::{Any, TypeId},
+    sync::Arc,
+};
+
+use parking_lot::RwLock;
+
+pub trait ComponentSet {
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, run: R);
+}
+
+impl ComponentSet for () {
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, _run: R) {}
+}
+
+impl<C0> ComponentSet for (C0,)
+where
+    C0: Any + Send + Sync,
+{
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, mut run: R) {
+        run(self.0.type_id(), Arc::new(RwLock::new(self.0)));
+    }
+}
+
+impl<C0, C1> ComponentSet for (C0, C1)
+where
+    C0: Any + Send + Sync,
+    C1: Any + Send + Sync,
+{
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, mut run: R) {
+        run(self.0.type_id(), Arc::new(RwLock::new(self.0)));
+        run(self.1.type_id(), Arc::new(RwLock::new(self.1)));
+    }
+}
+
+impl<C0, C1, C2> ComponentSet for (C0, C1, C2)
+where
+    C0: Any + Send + Sync,
+    C1: Any + Send + Sync,
+    C2: Any + Send + Sync,
+{
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, mut run: R) {
+        run(self.0.type_id(), Arc::new(RwLock::new(self.0)));
+        run(self.1.type_id(), Arc::new(RwLock::new(self.1)));
+        run(self.2.type_id(), Arc::new(RwLock::new(self.2)));
+    }
+}
+
+impl<C0, C1, C2, C3> ComponentSet for (C0, C1, C2, C3)
+where
+    C0: Any + Send + Sync,
+    C1: Any + Send + Sync,
+    C2: Any + Send + Sync,
+    C3: Any + Send + Sync,
+{
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, mut run: R) {
+        run(self.0.type_id(), Arc::new(RwLock::new(self.0)));
+        run(self.1.type_id(), Arc::new(RwLock::new(self.1)));
+        run(self.2.type_id(), Arc::new(RwLock::new(self.2)));
+        run(self.3.type_id(), Arc::new(RwLock::new(self.3)));
+    }
+}

--- a/src/entities/component_set.rs
+++ b/src/entities/component_set.rs
@@ -60,3 +60,136 @@ where
         run(self.3.type_id(), Arc::new(RwLock::new(self.3)));
     }
 }
+
+impl<C0, C1, C2, C3, C4> ComponentSet for (C0, C1, C2, C3, C4)
+where
+    C0: Any + Send + Sync,
+    C1: Any + Send + Sync,
+    C2: Any + Send + Sync,
+    C3: Any + Send + Sync,
+    C4: Any + Send + Sync,
+{
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, mut run: R) {
+        run(self.0.type_id(), Arc::new(RwLock::new(self.0)));
+        run(self.1.type_id(), Arc::new(RwLock::new(self.1)));
+        run(self.2.type_id(), Arc::new(RwLock::new(self.2)));
+        run(self.3.type_id(), Arc::new(RwLock::new(self.3)));
+        run(self.4.type_id(), Arc::new(RwLock::new(self.4)));
+    }
+}
+
+impl<C0, C1, C2, C3, C4, C5> ComponentSet for (C0, C1, C2, C3, C4, C5)
+where
+    C0: Any + Send + Sync,
+    C1: Any + Send + Sync,
+    C2: Any + Send + Sync,
+    C3: Any + Send + Sync,
+    C4: Any + Send + Sync,
+    C5: Any + Send + Sync,
+{
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, mut run: R) {
+        run(self.0.type_id(), Arc::new(RwLock::new(self.0)));
+        run(self.1.type_id(), Arc::new(RwLock::new(self.1)));
+        run(self.2.type_id(), Arc::new(RwLock::new(self.2)));
+        run(self.3.type_id(), Arc::new(RwLock::new(self.3)));
+        run(self.4.type_id(), Arc::new(RwLock::new(self.4)));
+        run(self.5.type_id(), Arc::new(RwLock::new(self.5)));
+    }
+}
+
+impl<C0, C1, C2, C3, C4, C5, C6> ComponentSet for (C0, C1, C2, C3, C4, C5, C6)
+where
+    C0: Any + Send + Sync,
+    C1: Any + Send + Sync,
+    C2: Any + Send + Sync,
+    C3: Any + Send + Sync,
+    C4: Any + Send + Sync,
+    C5: Any + Send + Sync,
+    C6: Any + Send + Sync,
+{
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, mut run: R) {
+        run(self.0.type_id(), Arc::new(RwLock::new(self.0)));
+        run(self.1.type_id(), Arc::new(RwLock::new(self.1)));
+        run(self.2.type_id(), Arc::new(RwLock::new(self.2)));
+        run(self.3.type_id(), Arc::new(RwLock::new(self.3)));
+        run(self.4.type_id(), Arc::new(RwLock::new(self.4)));
+        run(self.5.type_id(), Arc::new(RwLock::new(self.5)));
+        run(self.6.type_id(), Arc::new(RwLock::new(self.6)));
+    }
+}
+
+impl<C0, C1, C2, C3, C4, C5, C6, C7> ComponentSet for (C0, C1, C2, C3, C4, C5, C6, C7)
+where
+    C0: Any + Send + Sync,
+    C1: Any + Send + Sync,
+    C2: Any + Send + Sync,
+    C3: Any + Send + Sync,
+    C4: Any + Send + Sync,
+    C5: Any + Send + Sync,
+    C6: Any + Send + Sync,
+    C7: Any + Send + Sync,
+{
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, mut run: R) {
+        run(self.0.type_id(), Arc::new(RwLock::new(self.0)));
+        run(self.1.type_id(), Arc::new(RwLock::new(self.1)));
+        run(self.2.type_id(), Arc::new(RwLock::new(self.2)));
+        run(self.3.type_id(), Arc::new(RwLock::new(self.3)));
+        run(self.4.type_id(), Arc::new(RwLock::new(self.4)));
+        run(self.5.type_id(), Arc::new(RwLock::new(self.5)));
+        run(self.6.type_id(), Arc::new(RwLock::new(self.6)));
+        run(self.7.type_id(), Arc::new(RwLock::new(self.7)));
+    }
+}
+
+impl<C0, C1, C2, C3, C4, C5, C6, C7, C8> ComponentSet for (C0, C1, C2, C3, C4, C5, C6, C7, C8)
+where
+    C0: Any + Send + Sync,
+    C1: Any + Send + Sync,
+    C2: Any + Send + Sync,
+    C3: Any + Send + Sync,
+    C4: Any + Send + Sync,
+    C5: Any + Send + Sync,
+    C6: Any + Send + Sync,
+    C7: Any + Send + Sync,
+    C8: Any + Send + Sync,
+{
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, mut run: R) {
+        run(self.0.type_id(), Arc::new(RwLock::new(self.0)));
+        run(self.1.type_id(), Arc::new(RwLock::new(self.1)));
+        run(self.2.type_id(), Arc::new(RwLock::new(self.2)));
+        run(self.3.type_id(), Arc::new(RwLock::new(self.3)));
+        run(self.4.type_id(), Arc::new(RwLock::new(self.4)));
+        run(self.5.type_id(), Arc::new(RwLock::new(self.5)));
+        run(self.6.type_id(), Arc::new(RwLock::new(self.6)));
+        run(self.7.type_id(), Arc::new(RwLock::new(self.7)));
+        run(self.8.type_id(), Arc::new(RwLock::new(self.8)));
+    }
+}
+
+impl<C0, C1, C2, C3, C4, C5, C6, C7, C8, C9> ComponentSet
+    for (C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)
+where
+    C0: Any + Send + Sync,
+    C1: Any + Send + Sync,
+    C2: Any + Send + Sync,
+    C3: Any + Send + Sync,
+    C4: Any + Send + Sync,
+    C5: Any + Send + Sync,
+    C6: Any + Send + Sync,
+    C7: Any + Send + Sync,
+    C8: Any + Send + Sync,
+    C9: Any + Send + Sync,
+{
+    fn for_components<R: FnMut(TypeId, Arc<RwLock<dyn Any + Send + Sync>>)>(self, mut run: R) {
+        run(self.0.type_id(), Arc::new(RwLock::new(self.0)));
+        run(self.1.type_id(), Arc::new(RwLock::new(self.1)));
+        run(self.2.type_id(), Arc::new(RwLock::new(self.2)));
+        run(self.3.type_id(), Arc::new(RwLock::new(self.3)));
+        run(self.4.type_id(), Arc::new(RwLock::new(self.4)));
+        run(self.5.type_id(), Arc::new(RwLock::new(self.5)));
+        run(self.6.type_id(), Arc::new(RwLock::new(self.6)));
+        run(self.7.type_id(), Arc::new(RwLock::new(self.7)));
+        run(self.8.type_id(), Arc::new(RwLock::new(self.8)));
+        run(self.9.type_id(), Arc::new(RwLock::new(self.9)));
+    }
+}

--- a/src/entities/query.rs
+++ b/src/entities/query.rs
@@ -28,7 +28,7 @@ impl<'a> Query<'a> {
     pub fn with_component<T: Any>(&mut self) -> Result<&mut Self, EntityError> {
         let type_id = TypeId::of::<T>();
         if let Some(bit_mask) = self.entities.get_bitmask(&type_id) {
-            self.map |= bit_mask;
+            self.map.insert(*bit_mask);
             self.type_ids.push(type_id);
         } else {
             return Err(EntityError::ComponentNotRegistered);
@@ -42,7 +42,7 @@ impl<'a> Query<'a> {
     ///
     /// let mut world = World::new();
     /// world.register_component::<u32>();
-    /// world.create_entity().with_component(20_u32).unwrap();
+    /// world.create_entity((20_u32,)).unwrap();
     ///
     /// world.query()
     ///     .with_component::<u32>()
@@ -59,7 +59,7 @@ impl<'a> Query<'a> {
             .par_iter()
             .enumerate()
             .filter_map(|(index, entity_map)| {
-                if entity_map & &self.map == self.map {
+                if self.map.is_subset(entity_map) {
                     Some(QueryEntity::new(index, self.entities))
                 } else {
                     None
@@ -97,7 +97,7 @@ mod test {
         let mut entities = Entities::default();
         entities.register_component::<u32>();
         entities.register_component::<f32>();
-        entities.create_entity((10_u32,)).unwrap();
+        entities.create_entity((10_u32, 20.0_f32)).unwrap();
         entities.create_entity((5_u32,)).unwrap();
         entities.create_entity((20.0_f32,)).unwrap();
         entities.create_entity((15_u32, 25.0_f32)).unwrap();

--- a/src/entities/query.rs
+++ b/src/entities/query.rs
@@ -97,20 +97,10 @@ mod test {
         let mut entities = Entities::default();
         entities.register_component::<u32>();
         entities.register_component::<f32>();
-        entities
-            .create_entity()
-            .with_component(10_u32)
-            .unwrap()
-            .with_component(20.0_f32)
-            .unwrap();
-        entities.create_entity().with_component(5_u32).unwrap();
-        entities.create_entity().with_component(20.0_f32).unwrap();
-        entities
-            .create_entity()
-            .with_component(15_u32)
-            .unwrap()
-            .with_component(25.0_f32)
-            .unwrap();
+        entities.create_entity((10_u32,)).unwrap();
+        entities.create_entity((5_u32,)).unwrap();
+        entities.create_entity((20.0_f32,)).unwrap();
+        entities.create_entity((15_u32, 25.0_f32)).unwrap();
 
         Query::new(&entities)
             .with_component::<u32>()

--- a/src/entities/query_entity.rs
+++ b/src/entities/query_entity.rs
@@ -12,6 +12,7 @@ type ExtractedComponents<'a> =
     Result<RwLockReadGuard<'a, Vec<Option<Arc<RwLock<dyn Any + Send + Sync>>>>>, EntityError>;
 
 /// A query entity with the entities id and a reference to the [`Entities`] struct.
+#[derive(Debug)]
 pub struct QueryEntity<'a> {
     pub id: usize,
     entities: &'a Entities,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@
 
 use std::any::Any;
 
-use entities::{query::Query, Entities, EntitiesWithIntoIndex};
-use error::ResourceError;
+use entities::{component_set::ComponentSet, query::Query, Entities};
+use error::{EntityError, ResourceError};
 use resources::Resources;
 
 /// Provides the [`Entities`] struct as well as [`query`](entities::query) and [`query_entity`](entities::query_entity) modules.
@@ -104,8 +104,8 @@ impl World {
     }
 
     /// Spawn an entity
-    pub fn create_entity(&self) -> EntitiesWithIntoIndex {
-        self.entities.create_entity()
+    pub fn create_entity(&self, components: impl ComponentSet) -> Result<(), EntityError> {
+        self.entities.create_entity(components)
     }
 
     /// Get a [`Query`] on the [`World`]'s [`Entities`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! world.add_resource(10_u32);
 //!
 //! // create an entity with registered component
-//! world.create_entity().with_component(20_u32).unwrap();
+//! world.create_entity((20_u32,)).unwrap();
 //! ```
 
 use std::any::Any;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 
 use std::any::Any;
 
-use entities::{query::Query, Entities};
+use entities::{query::Query, Entities, EntitiesWithIntoIndex};
 use error::ResourceError;
 use resources::Resources;
 
@@ -104,7 +104,7 @@ impl World {
     }
 
     /// Spawn an entity
-    pub fn create_entity(&self) -> &Entities {
+    pub fn create_entity(&self) -> EntitiesWithIntoIndex {
         self.entities.create_entity()
     }
 

--- a/src/systems/dispatcher.rs
+++ b/src/systems/dispatcher.rs
@@ -133,10 +133,10 @@ mod tests {
     }
 
     fn system_1(world: &World) {
-        world.create_entity().with_component(1_u32).unwrap();
+        world.create_entity((1_u32,)).unwrap();
     }
     fn system_2(world: &World) {
-        world.create_entity().with_component(2_u32).unwrap();
+        world.create_entity((2_u32,)).unwrap();
     }
     fn system_3(world: &World) {
         world
@@ -148,9 +148,9 @@ mod tests {
                     .iter()
                     .for_each(|entity| entity.component_mut(|comp: &mut u32| *comp += 1).unwrap())
             });
-        world.create_entity().with_component(3_u32).unwrap();
+        world.create_entity((3_u32,)).unwrap();
     }
     fn system_4(world: &World) {
-        world.create_entity().with_component(4_u32).unwrap();
+        world.create_entity((4_u32,)).unwrap();
     }
 }

--- a/tests/entities.rs
+++ b/tests/entities.rs
@@ -5,14 +5,14 @@ fn create_entity() {
     let mut world = World::new();
     world.register_component::<u64>();
 
-    world.create_entity().with_component(400_u64).unwrap();
+    world.create_entity((400_u64,)).unwrap();
 }
 
 #[test]
 fn query() {
     let mut world = World::new();
     world.register_component::<u32>();
-    world.create_entity().with_component(32_u32).unwrap();
+    world.create_entity((32_u32,)).unwrap();
 
     let mut bool = false;
     world
@@ -32,7 +32,7 @@ fn query() {
                 entity.remove_component::<u32>().unwrap();
                 entity.add_component(32_u32).unwrap();
                 entity.delete();
-                world.create_entity().with_component(32_u32).unwrap();
+                world.create_entity((32_u32,)).unwrap();
             }
         });
     assert!(bool);
@@ -43,12 +43,7 @@ fn inner_lock() {
     let mut world = World::new();
     world.register_component::<u32>();
     world.register_component::<f32>();
-    world
-        .create_entity()
-        .with_component(32_u32)
-        .unwrap()
-        .with_component(64_f32)
-        .unwrap();
+    world.create_entity((32_u32, 64.0_f32)).unwrap();
 
     world
         .query()

--- a/tests/systems.rs
+++ b/tests/systems.rs
@@ -11,6 +11,27 @@ fn create_systems() {
 
 #[test]
 fn dispatcher() {
+    use parking_lot::deadlock;
+    use std::thread;
+    use std::time::Duration;
+
+    thread::spawn(move || loop {
+        thread::sleep(Duration::from_secs(2));
+        let deadlocks = deadlock::check_deadlock();
+        if deadlocks.is_empty() {
+            continue;
+        }
+
+        println!("{} deadlocks detected", deadlocks.len());
+        for (i, threads) in deadlocks.iter().enumerate() {
+            println!("Deadlock #{}", i);
+            for t in threads {
+                println!("Thread Id {:#?}", t.thread_id());
+                println!("{:#?}", t.backtrace());
+            }
+        }
+    });
+
     let mut world = World::new();
     world.register_component::<u32>();
 

--- a/tests/systems.rs
+++ b/tests/systems.rs
@@ -51,7 +51,6 @@ fn dispatcher() {
             entities[0]
                 .component_ref(|component: &u32| assert_eq!(*component, 2))
                 .unwrap();
-            println!("{:?}", entities);
             entities[3]
                 .component_ref(|component: &u32| assert_eq!(*component, 4))
                 .unwrap();

--- a/tests/systems.rs
+++ b/tests/systems.rs
@@ -51,6 +51,7 @@ fn dispatcher() {
             entities[0]
                 .component_ref(|component: &u32| assert_eq!(*component, 2))
                 .unwrap();
+            println!("{:?}", entities);
             entities[3]
                 .component_ref(|component: &u32| assert_eq!(*component, 4))
                 .unwrap();
@@ -59,13 +60,13 @@ fn dispatcher() {
 
 // test systems
 fn system_1(world: &World) {
-    world.create_entity().with_component(1_u32).unwrap();
+    world.create_entity((1_u32,)).unwrap();
 }
 fn system_2(world: &World) {
-    world.create_entity().with_component(2_u32).unwrap();
+    world.create_entity((2_u32,)).unwrap();
 }
 fn system_3(world: &World) {
-    world.create_entity().with_component(3_u32).unwrap();
+    world.create_entity((3_u32,)).unwrap();
     world
         .query()
         .with_component::<u32>()
@@ -77,5 +78,5 @@ fn system_3(world: &World) {
         });
 }
 fn system_4(world: &World) {
-    world.create_entity().with_component(4_u32).unwrap();
+    world.create_entity((4_u32,)).unwrap();
 }


### PR DESCRIPTION
### What this changes

- API for creating entities: `world.create_entity().with_component(...)` -> `world.create_entity((..., ...))`
- Performance improvements to bitmaps/masks
    - The bitmasks are now using `u32`s, because using a whole bitmap to store just one integer is dumb.

closes #23